### PR TITLE
Add output for kodi-out node (Fixes #4)

### DIFF
--- a/kodi.html
+++ b/kodi.html
@@ -107,7 +107,7 @@
             kodicommand: {value: ""}
         },
         inputs: 1,
-        outputs: 0,
+        outputs: 1,
         align: 'right',
         icon: "bridge-dash.png",
         label: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-kodi",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "Node-RED nodes for communicating with a Kodi (former XBMC).",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds an optional output to the kodi-out-node. This is a practical solution for sending back the data received from kodi.